### PR TITLE
make viewer the only route

### DIFF
--- a/platform/viewer/src/routes/routesUtil.js
+++ b/platform/viewer/src/routes/routesUtil.js
@@ -4,77 +4,22 @@ import OHIF from '@ohif/core';
 const { urlUtil: UrlUtil } = OHIF.utils;
 
 // Dynamic Import Routes (CodeSplitting)
-const IHEInvokeImageDisplay = asyncComponent(() =>
-  retryImport(() =>
-    import(/* webpackChunkName: "IHEInvokeImageDisplay" */ './IHEInvokeImageDisplay.js')
-  )
-);
 const ViewerRouting = asyncComponent(() =>
-  retryImport(() => import(/* webpackChunkName: "ViewerRouting" */ './ViewerRouting.js'))
-);
-
-const StudyListRouting = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "StudyListRouting" */ '../studylist/StudyListRouting.js'
-  ))
-);
-const StandaloneRouting = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "ConnectedStandaloneRouting" */ '../connectedComponents/ConnectedStandaloneRouting.js'
-  ))
-);
-const ViewerLocalFileData = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "ViewerLocalFileData" */ '../connectedComponents/ViewerLocalFileData.js'
-  ))
+  retryImport(() =>
+    import(/* webpackChunkName: "ViewerRouting" */ './ViewerRouting.js')
+  )
 );
 
 const reload = () => window.location.reload();
 
+// Originally, many routes where supported. For purposes of this modication
+// only one route was left but the overall code functionality is the same.
+
 const ROUTES_DEF = {
   default: {
     viewer: {
-      path: '/viewer/:studyInstanceUIDs',
+      path: '/',
       component: ViewerRouting,
-    },
-    standaloneViewer: {
-      path: '/viewer',
-      component: StandaloneRouting,
-    },
-    list: {
-      path: ['/studylist', '/'],
-      component: StudyListRouting,
-      condition: appConfig => {
-        return appConfig.showStudyList;
-      },
-    },
-    local: {
-      path: '/local',
-      component: ViewerLocalFileData,
-    },
-    IHEInvokeImageDisplay: {
-      path: '/IHEInvokeImageDisplay',
-      component: IHEInvokeImageDisplay
-    },
-  },
-  gcloud: {
-    viewer: {
-      path:
-        '/projects/:project/locations/:location/datasets/:dataset/dicomStores/:dicomStore/study/:studyInstanceUIDs',
-      component: ViewerRouting,
-      condition: appConfig => {
-        return !!appConfig.enableGoogleCloudAdapter;
-      },
-    },
-    list: {
-      path:
-        '/projects/:project/locations/:location/datasets/:dataset/dicomStores/:dicomStore',
-      component: StudyListRouting,
-      condition: appConfig => {
-        const showList = appConfig.showStudyList;
-
-        return showList && !!appConfig.enableGoogleCloudAdapter;
-      },
     },
   },
 };


### PR DESCRIPTION
Remove routes that will no longer be used and make Viewer the only route available. At the same time, make the viewer pick up the studyInstanceIDs from the `app-config.js` file instead of the url.

https://github.com/danielvelazquezg/Viewers/projects/2#card-52529174
https://github.com/danielvelazquezg/Viewers/projects/2#card-52529222
https://github.com/danielvelazquezg/Viewers/projects/2#card-52529203
