### PR TITLE
add custom html file and settings to compile for stand-alone

### DIFF
--- a/platform/viewer/.env
+++ b/platform/viewer/.env
@@ -6,5 +6,6 @@
 # Be careful not to commit anything sensitive to source control.
 #
 
-PUBLIC_URL=/
+PUBLIC_URL=/dicomviewer/
 APP_CONFIG=config/default.js
+HTML_TEMPLATE=iframe.html

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -1,8 +1,8 @@
 window.config = {
   // default: '/'
-  routerBasename: '/',
+  routerBasename: '/dicomviewer/index.html',
   extensions: [],
-  showStudyList: true,
+  showStudyList: false,
   filterQueryParam: false,
   servers: {
     dicomWeb: [

--- a/platform/viewer/public/html-templates/iframe.html
+++ b/platform/viewer/public/html-templates/iframe.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1,maximum-scale=1,user-scalable=no" />
+    <meta charset="utf-8" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+    <title></title>
+</head>
+<body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+
+    <div id="root"></div>
+
+    <script>
+        var localUID = location.search.split('=')[1];
+        window.config.studyInstanceUIDs = localUID;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add custom html file and some setting so the project can now be compiled as stand-alone `yarn run build` instead of umd module (`yarn run build:package`)

Also, takes into account that application runs from /dicomviewer/ instead of root url.